### PR TITLE
remove min-height from profile container

### DIFF
--- a/frontend/src/custom.scss
+++ b/frontend/src/custom.scss
@@ -55,7 +55,3 @@ body {
   display: -webkit-box;
   -webkit-box-orient: vertical;
 }
-
-.user-info {
-  min-width: 800px;
-}


### PR DESCRIPTION
# Fix profile page view on mobile

Currently on mobile view, the profile page looks stretched outside of the viewport. This fix will remove the minimum height set on the container
